### PR TITLE
Add SAT algorithm examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.10)
 project(MPI)
 
 set(CMAKE_CXX_STANDARD 20)
 
-add_executable(MPI main.cpp)
+add_executable(resolution resolution.cpp)
+add_executable(dp dp.cpp)
+add_executable(dpll dpll.cpp)
+add_executable(cdcl cdcl.cpp)
+add_executable(grasp grasp.cpp)

--- a/cdcl.cpp
+++ b/cdcl.cpp
@@ -1,0 +1,62 @@
+#include "sat_utils.h"
+
+CNF assign_literal_cl(const CNF& f, int lit, bool& conflict) {
+    CNF out;
+    for (const auto& c : f) {
+        if (std::find(c.begin(), c.end(), lit) != c.end()) continue;
+        Clause new_c;
+        for (int l : c) if (l != -lit) new_c.push_back(l);
+        if (new_c.empty()) {
+            conflict = true;
+            return {};
+        }
+        out.push_back(new_c);
+    }
+    return out;
+}
+
+bool cdcl_recursive(CNF formula) {
+    while (true) {
+        bool unit = false;
+        for (const auto& c : formula) {
+            if (c.size() == 1) {
+                bool conflict = false;
+                formula = assign_literal_cl(formula, c[0], conflict);
+                if (conflict) return false;
+                unit = true;
+                break;
+            }
+        }
+        if (!unit) break;
+    }
+    if (formula.empty()) return true;
+    for (const auto& c : formula) if (c.empty()) return false;
+    int lit = formula[0][0];
+    bool conflict = false;
+    CNF f_true = assign_literal_cl(formula, lit, conflict);
+    if (!conflict && cdcl_recursive(f_true)) return true;
+    // learn clause { -lit }
+    formula.push_back({-lit});
+    conflict = false;
+    CNF f_false = assign_literal_cl(formula, -lit, conflict);
+    if (!conflict) return cdcl_recursive(f_false);
+    return false;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <instances>\n";
+        return 1;
+    }
+    int instances = std::stoi(argv[1]);
+    const int vars = 6;
+    const int clauses = 10;
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < instances; ++i) {
+        CNF f = generate_random_formula(vars, clauses);
+        cdcl_recursive(f);
+    }
+    auto end = std::chrono::steady_clock::now();
+    print_result("CDCL", instances, start, end);
+    return 0;
+}

--- a/dp.cpp
+++ b/dp.cpp
@@ -1,0 +1,51 @@
+#include "sat_utils.h"
+
+bool dp_unsat(CNF formula) {
+    while (true) {
+        if (formula.empty()) return false; // no clauses -> sat
+        for (const auto& c : formula) if (c.empty()) return true; // empty clause -> unsat
+        int var = 0;
+        for (const auto& c : formula) {
+            if (!c.empty()) { var = std::abs(c.front()); break; }
+        }
+        if (var == 0) return false;
+        CNF pos, neg, rest;
+        for (const auto& c : formula) {
+            if (std::find(c.begin(), c.end(), var) != c.end()) pos.push_back(c);
+            else if (std::find(c.begin(), c.end(), -var) != c.end()) neg.push_back(c);
+            else rest.push_back(c);
+        }
+        if (pos.empty() || neg.empty()) { // pure literal
+            formula = rest;
+            continue;
+        }
+        for (const auto& c1 : pos) {
+            for (const auto& c2 : neg) {
+                Clause r;
+                for (int lit : c1) if (lit != var) if (std::find(r.begin(), r.end(), lit) == r.end()) r.push_back(lit);
+                for (int lit : c2) if (lit != -var && std::find(r.begin(), r.end(), lit) == r.end()) r.push_back(lit);
+                if (r.empty()) return true;
+                rest.push_back(r);
+            }
+        }
+        formula = rest;
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <instances>\n";
+        return 1;
+    }
+    int instances = std::stoi(argv[1]);
+    const int vars = 6;
+    const int clauses = 10;
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < instances; ++i) {
+        CNF f = generate_random_formula(vars, clauses);
+        dp_unsat(f);
+    }
+    auto end = std::chrono::steady_clock::now();
+    print_result("DP", instances, start, end);
+    return 0;
+}

--- a/dpll.cpp
+++ b/dpll.cpp
@@ -1,0 +1,64 @@
+#include "sat_utils.h"
+
+CNF assign_literal(const CNF& f, int lit, bool& conflict) {
+    CNF out;
+    for (const auto& c : f) {
+        if (std::find(c.begin(), c.end(), lit) != c.end()) continue; // clause satisfied
+        Clause new_c;
+        bool empty = true;
+        for (int l : c) {
+            if (l == -lit) continue; // remove
+            new_c.push_back(l);
+        }
+        if (new_c.empty()) {
+            conflict = true;
+            return {};
+        }
+        out.push_back(new_c);
+    }
+    return out;
+}
+
+bool dpll(CNF f) {
+    while (true) {
+        bool unit = false;
+        for (const auto& c : f) {
+            if (c.size() == 1) {
+                bool conflict = false;
+                f = assign_literal(f, c[0], conflict);
+                if (conflict) return false;
+                unit = true;
+                break;
+            }
+        }
+        if (!unit) break;
+    }
+    if (f.empty()) return true;
+    for (const auto& c : f) if (c.empty()) return false;
+    int lit = f[0][0];
+    bool conflict = false;
+    CNF f_true = assign_literal(f, lit, conflict);
+    if (!conflict && dpll(f_true)) return true;
+    conflict = false;
+    CNF f_false = assign_literal(f, -lit, conflict);
+    if (!conflict) return dpll(f_false);
+    return false;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <instances>\n";
+        return 1;
+    }
+    int instances = std::stoi(argv[1]);
+    const int vars = 6;
+    const int clauses = 10;
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < instances; ++i) {
+        CNF f = generate_random_formula(vars, clauses);
+        dpll(f);
+    }
+    auto end = std::chrono::steady_clock::now();
+    print_result("DPLL", instances, start, end);
+    return 0;
+}

--- a/grasp.cpp
+++ b/grasp.cpp
@@ -1,0 +1,62 @@
+#include "sat_utils.h"
+
+CNF assign_literal_gr(const CNF& f, int lit, bool& conflict) {
+    CNF out;
+    for (const auto& c : f) {
+        if (std::find(c.begin(), c.end(), lit) != c.end()) continue;
+        Clause new_c;
+        for (int l : c) if (l != -lit) new_c.push_back(l);
+        if (new_c.empty()) { conflict = true; return {}; }
+        out.push_back(new_c);
+    }
+    return out;
+}
+
+bool grasp_recursive(CNF formula) {
+    while (true) {
+        bool unit = false;
+        for (const auto& c : formula) {
+            if (c.size() == 1) {
+                bool conflict = false;
+                formula = assign_literal_gr(formula, c[0], conflict);
+                if (conflict) return false;
+                unit = true;
+                break;
+            }
+        }
+        if (!unit) break;
+    }
+    if (formula.empty()) return true;
+    for (const auto& c : formula) if (c.empty()) return false;
+    // pick random literal
+    static std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<size_t> dist(0, formula.size() - 1);
+    int lit = formula[dist(rng)][0];
+    bool conflict = false;
+    CNF f_true = assign_literal_gr(formula, lit, conflict);
+    if (!conflict && grasp_recursive(f_true)) return true;
+    // learn clause { -lit }
+    formula.push_back({-lit});
+    conflict = false;
+    CNF f_false = assign_literal_gr(formula, -lit, conflict);
+    if (!conflict) return grasp_recursive(f_false);
+    return false;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <instances>\n";
+        return 1;
+    }
+    int instances = std::stoi(argv[1]);
+    const int vars = 6;
+    const int clauses = 10;
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < instances; ++i) {
+        CNF f = generate_random_formula(vars, clauses);
+        grasp_recursive(f);
+    }
+    auto end = std::chrono::steady_clock::now();
+    print_result("GRASP", instances, start, end);
+    return 0;
+}

--- a/resolution.cpp
+++ b/resolution.cpp
@@ -1,0 +1,51 @@
+#include "sat_utils.h"
+#include <set>
+
+bool resolution_unsat(CNF formula) {
+    for (auto &c : formula) std::sort(c.begin(), c.end());
+    std::set<Clause> clauses(formula.begin(), formula.end());
+    bool changed = true;
+    while (changed && clauses.size() < 500) {
+        changed = false;
+        std::vector<Clause> new_clauses;
+        for (auto it1 = clauses.begin(); it1 != clauses.end(); ++it1) {
+            for (auto it2 = std::next(it1); it2 != clauses.end(); ++it2) {
+                for (int lit : *it1) {
+                    if (std::find(it2->begin(), it2->end(), -lit) != it2->end()) {
+                        Clause resolvent;
+                        for (int l : *it1) if (l != lit) resolvent.push_back(l);
+                        for (int l : *it2) if (l != -lit && std::find(resolvent.begin(), resolvent.end(), l) == resolvent.end()) resolvent.push_back(l);
+                        std::sort(resolvent.begin(), resolvent.end());
+                        if (resolvent.empty()) return true; // empty clause
+                        if (!clauses.count(resolvent)) {
+                            new_clauses.push_back(resolvent);
+                        }
+                    }
+                }
+            }
+        }
+        if (!new_clauses.empty()) {
+            changed = true;
+            for (auto &c : new_clauses) clauses.insert(c);
+        }
+    }
+    return false; // satisfiable if no empty clause derived
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <instances>\n";
+        return 1;
+    }
+    int instances = std::stoi(argv[1]);
+    const int vars = 6;
+    const int clauses = 10;
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < instances; ++i) {
+        CNF f = generate_random_formula(vars, clauses);
+        resolution_unsat(f);
+    }
+    auto end = std::chrono::steady_clock::now();
+    print_result("Resolution", instances, start, end);
+    return 0;
+}

--- a/sat_utils.h
+++ b/sat_utils.h
@@ -1,0 +1,48 @@
+#ifndef SAT_UTILS_H
+#define SAT_UTILS_H
+
+#include <vector>
+#include <random>
+#include <chrono>
+#include <sys/resource.h>
+#include <iostream>
+
+using Clause = std::vector<int>;
+using CNF = std::vector<Clause>;
+
+// Generate a random 3-SAT formula with given number of variables and clauses
+inline CNF generate_random_formula(int variables, int clauses) {
+    static std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<int> var_dist(1, variables);
+    std::uniform_int_distribution<int> sign_dist(0, 1);
+    CNF formula;
+    for (int i = 0; i < clauses; ++i) {
+        Clause clause;
+        for (int j = 0; j < 3; ++j) {
+            int var = var_dist(rng);
+            int lit = sign_dist(rng) ? var : -var;
+            clause.push_back(lit);
+        }
+        formula.push_back(clause);
+    }
+    return formula;
+}
+
+inline long get_memory_usage_kb() {
+    struct rusage usage{};
+    if (getrusage(RUSAGE_SELF, &usage) == 0) {
+        return usage.ru_maxrss; // in kilobytes
+    }
+    return 0;
+}
+
+inline void print_result(const std::string& name, int instances,
+                        const std::chrono::steady_clock::time_point& start,
+                        const std::chrono::steady_clock::time_point& end) {
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    long mem_kb = get_memory_usage_kb();
+    std::cout << name << " solved " << instances << " instance(s) in "
+              << duration << " ms. Memory used: " << mem_kb << " KB\n";
+}
+
+#endif // SAT_UTILS_H


### PR DESCRIPTION
## Summary
- add utilities for generating random CNF formulas and timing helpers
- implement simple resolution, DP, DPLL, CDCL and GRASP SAT solvers
- add CMake targets for each solver

## Testing
- `cmake .. && make -j$(nproc)`
- `./resolution 1`
- `./dp 1`
- `./dpll 1`
- `./cdcl 1`
- `./grasp 1`

------
https://chatgpt.com/codex/tasks/task_e_6843612b0c18832281ea75f3bc38fb0b